### PR TITLE
Add -s/--source parameter

### DIFF
--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -1,4 +1,4 @@
-py3createtorrent
+﻿py3createtorrent
 ================
 
 *Create torrents via command line!*
@@ -233,6 +233,15 @@ BitTorrent clients in the torrent info.
 
 By default py3createtorrent uses "created by py3createtorrent <version>" as
 comment (to change this behavior, consult the :ref:`configuration` section).
+
+Source (``-s``)
+^^^^^^^^^^^^^^^
+
+The source field is a non-standard metainfo field used by private trackers to
+reduce issues (such as misreported stats) caused by cross-seeding.  For
+private trackers that forbid their torrent files from being uploaded elsewhere,
+it ensures that torrent files uploaded to the tracker from a different source
+are unique to the private tracker.
 
 Force (``-f``)
 ^^^^^^^^^^^^^^

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -151,6 +151,8 @@ Syntax::
      -P, --private         create private torrent
      -c COMMENT, --comment=COMMENT
                            include comment
+     -s SOURCE, --source=SOURCE
+	                       include torrent source
      -f, --force           dont ask anything, just do it
      -v, --verbose         verbose mode
      -q, --quiet           be quiet, e.g. don't print summary

--- a/src/py3createtorrent.py
+++ b/src/py3createtorrent.py
@@ -670,7 +670,7 @@ def main(argv):
     if options.private:
         info['private'] = 1
 
-    # re-use the name regex for source
+    # Re-use the name regex for source parameter.
     if options.source:
         options.source = options.source.strip()
 

--- a/src/py3createtorrent.py
+++ b/src/py3createtorrent.py
@@ -670,6 +670,18 @@ def main(argv):
     if options.private:
         info['private'] = 1
 
+    # re-use the name regex for source
+    if options.source:
+        options.source = options.source.strip()
+
+        regexp = re.compile("^[A-Z0-9_\-\., ]+$", re.I)
+
+        if not regexp.match(options.source):
+            parser.error("Invalid source: '%s'. Allowed chars: A_Z, a-z, 0-9, "
+                         "any of {.,_-} plus spaces." % options.source)
+
+        info['source'] = options.source
+
     # Construct outer metainfo dict, which contains the torrent's whole
     # information.
     metainfo =  {

--- a/src/py3createtorrent.py
+++ b/src/py3createtorrent.py
@@ -486,6 +486,10 @@ def main(argv):
                       dest="comment", default=False,
                       help="include comment")
 
+    parser.add_option("-s", "--source", type="string", action="store",
+                      dest="source", default=False,
+                      help="include source")
+
     parser.add_option("-f", "--force", action="store_true",
                       dest="force", default=False,
                       help="dont ask anything, just do it")


### PR DESCRIPTION
Adds a -s/--source parameter to allow you to specify the torrent's source.  This is a required metainfo field for uploads to several private trackers.

![image](https://user-images.githubusercontent.com/52503242/70666098-d10d5880-1c22-11ea-89aa-2dc2dd5fb29b.png)
